### PR TITLE
Fix Send To Anki putting CSS into back template

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -177,7 +177,9 @@ chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
                                 <span>{{nextText}}</span>
                               `,
                               "Back": `
-                               `
+                                {{FrontSide}}
+                                <hr id=answer>
+                              `
                           }
                       ]
                   }

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -177,18 +177,6 @@ chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
                                 <span>{{nextText}}</span>
                               `,
                               "Back": `
-                                .card {
-                                  font-family: futura-pt,sans-serif,sans-serif;
-                                  font-size: 20px;
-                                  text-align: center;
-                                  color: black;
-                                  background-color: #e9e9e9;
-                                }
-                                
-                                span {
-                                  font-size: 0.9rem;
-                                  color: #3c3c3c;
-                                }
                                `
                           }
                       ]


### PR DESCRIPTION
I've "fixed" the bug by making the Send to Anki fill the back template with an empty string, but I wonder if there wouldn't be a better piece of information to show. 

It would be pretty handy if, assuming a video has 2 or more subtitles, one of the subtitles could be used to display data on the back template.

