### PR TITLE
Add a replay button to YouTube

### DIFF
--- a/src/popup/components/ExportAnki.js
+++ b/src/popup/components/ExportAnki.js
@@ -141,10 +141,11 @@ const createModel = async () => {
                       <span>{{prevText}}</span>
                       <br>
 
-                      {{text}}
+                      {{text}}<button onclick="document.getElementById('youtube_player').src = document.getElementById('youtube_player').src">Replay</button>
                       <br>
 
                       <iframe
+                          id="youtube_player"
                           width="560"
                           height="315"
                           src="https://www.youtube.com/embed/{{id}}?start={{startSeconds}}&end={{endSeconds}}&autoplay=1"


### PR DESCRIPTION
The current Anki card created by this extension does not seem to allow replay. So I would like to fix it. clicking the replay button on youtube does not work because the video plays from the beginning. So I am adding a button.
The reason I am adding the button above the Video is because the content below the video is not showing in my environment.
(Chrome extension + AnkiMac / AnkiDroid)

The replay code is from here.
https://stackoverflow.com/a/4062084/4339442