### PR TITLE
Undo merge and manifest improvements

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -12,7 +12,7 @@
 		"message": "Transcript not found"
 	},
 	"instructionsDescription": {
-		"message": "Please, open the transcript of the video"
+		"message": "Please, open the transcript of the video, sometimes is at the end of the video description"
 	},
 	"aboutDonate": {
 		"message": "Donate"
@@ -24,7 +24,7 @@
 		"message": "Suggestions"
 	},
 	"listDeleteSavedCards": {
-		"message": "Delete saved cards"
+		"message": "Delete modified cards"
 	},
 	"listDeleteSavedCardsTitle": {
 		"message": "Delete stored cards and get new ones"
@@ -49,6 +49,12 @@
 	},
 	"listMergeCards": {
 		"message": "Merge $1 cards"
+	},
+	"listUnmerge": {
+		"message": "Undo merge"
+	},
+	"listMergedCard": {
+		"message": "Merged from $1 cards"
 	},
 	"listExportCards": {
 		"message": "Export $1 cards"

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -12,7 +12,7 @@
 		"message": "Transcripción no encontrada"
 	},
 	"instructionsDescription": {
-		"message": "Por favor, abre la transcipción del video"
+		"message": "Por favor, abre la transcipción del video, algunas veces está al final de la descripción"
 	},
 	"aboutDonate": {
 		"message": "Donar"
@@ -24,7 +24,7 @@
 		"message": "Sugerencias"
 	},
 	"listDeleteSavedCards": {
-		"message": "Eliminar tarjetas guardadas"
+		"message": "Eliminar tarjetas modificadas"
 	},
 	"listDeleteSavedCardsTitle": {
 		"message": "Borra las tarjetas guardadas y obtiene nuevas"
@@ -49,6 +49,12 @@
 	},
 	"listMergeCards": {
 		"message": "Combinar $1 tarjeta"
+	},
+	"listUnmerge": {
+		"message": "Deshacer combinación"
+	},
+	"listMergedCard": {
+		"message": "Combinada de $1 tarjetas"
 	},
 	"listExportCards": {
 		"message": "Exportar $1 tarjeta"

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -10,4 +10,5 @@ export interface Subtitle {
     title: string;
     disabled?: boolean;
     hash: string;
+    mergedFrom?: Subtitle[];
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,6 +9,13 @@
   "author": "Daniel Doblado",
   "homepage_url": "https://github.com/dobladov/youtube2Anki",
 
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{fa9a6243-e7c0-4dc3-ba75-eb5a5e4c2aef}",
+      "strict_min_version": "121.0"
+    }
+  },
+
   "icons": {
     "16": "icons/icon16.png",
     "24": "icons/icon24.png",
@@ -17,13 +24,13 @@
   },
 
   "action": {
-    "browser_style": true,
     "default_icon": "icons/icon48.png",
     "default_title": "__MSG_exportTitle__",
     "default_popup": "popup/popup.html"
   },
 
   "background": {
+    "scripts": ["background.js"],
     "service_worker": "background.js"
   },
 

--- a/src/popup/components/Export.js
+++ b/src/popup/components/Export.js
@@ -2,7 +2,7 @@ import { div, css, h2, button, p } from '../skruv/html.js'
 
 import { state as mainState } from '../state.js'
 import { ExportAnki } from './ExportAnki.js'
-import { getEnabledSubtitles } from '../utils.js'
+import { getEnabledSubtitles, toPlainSubtitles } from '../utils.js'
 
 // @ts-ignore
 const styling = css`
@@ -43,7 +43,7 @@ export const Export = () => div(
           {
             type: 'download',
             title: mainState.title,
-            subtitles: getEnabledSubtitles(mainState.subtitles.map(v => ({ ...v })))
+            subtitles: getEnabledSubtitles(toPlainSubtitles(mainState.subtitles))
           }
         )
       }

--- a/src/popup/components/List.js
+++ b/src/popup/components/List.js
@@ -1,4 +1,4 @@
-import { div, css, ul, li, button, text, h2 } from '../skruv/html.js'
+import { div, css, ul, li, button, text, h2, span } from '../skruv/html.js'
 
 import { state as mainState } from '../state.js'
 import { getEnabledSubtitles } from '../utils.js'
@@ -36,7 +36,9 @@ const mergeCards = (cardsToMerge) => {
     text: cardsToMerge.map(({ text }) => text).join(' '),
     endSeconds: lastCard.endSeconds,
     nextTime: lastCard.nextTime,
-    nextText: lastCard.nextText
+    nextText: lastCard.nextText,
+    // Keep the original cards so the merge can be undone
+    mergedFrom: cardsToMerge
   }
 
   // Insert the new card in between the selection indexes
@@ -59,6 +61,29 @@ const mergeCards = (cardsToMerge) => {
   }
 
   // Reset selection
+  mainState.mergeStart = NaN
+  mainState.mergeEnd = NaN
+}
+
+/**
+ * Restores the original cards of a merged card
+ * back into the subtitles state
+ *
+ * @param {number} index
+ */
+const unmergeCard = (index) => {
+  const mergedFrom = mainState.subtitles[index].mergedFrom
+  if (!mergedFrom?.length) {
+    return
+  }
+
+  mainState.subtitles = [
+    ...mainState.subtitles.slice(0, index),
+    ...mergedFrom.map(v => ({ ...v })),
+    ...mainState.subtitles.slice(index + 1, mainState.subtitles.length)
+  ]
+
+  // Reset selection since the indexes have shifted
   mainState.mergeStart = NaN
   mainState.mergeEnd = NaN
 }
@@ -102,6 +127,13 @@ const styling = css`
   
   li {
     position: relative;
+  }
+
+  .mergedBadge {
+    color: var(--action-color);
+    font-size: .75rem;
+    font-weight: bold;
+    margin-left: .3rem;
   }
 
   .text {
@@ -163,7 +195,7 @@ const styling = css`
 
   .hidden {
     transition: opacity .5s ease-in-out;
-    pointer-events: none;
+    pointer-events: none !important;
     opacity: 0 !important;
   }
 
@@ -279,6 +311,12 @@ export const List = (storageId) => {
         div({},
           item.time
         ),
+        span({
+          class: 'mergedBadge',
+          title: item.mergedFrom?.length ? chrome.i18n.getMessage('listMergedCard', String(item.mergedFrom.length)) : undefined
+        },
+        item.mergedFrom?.length ? `×${item.mergedFrom.length}` : ''
+        ),
         div({
           class: 'text'
         },
@@ -303,7 +341,13 @@ export const List = (storageId) => {
           onclick: () => {
             mergeCards(cardsToMerge)
           }
-        }, chrome.i18n.getMessage('listMergeCards', String(cardsToMerge.length))))
+        }, chrome.i18n.getMessage('listMergeCards', String(cardsToMerge.length))),
+        button({
+          class: `btn floating right${item.mergedFrom?.length && cardsToMerge.length <= 1 ? '' : ' hidden'}`,
+          onclick: () => {
+            unmergeCard(i)
+          }
+        }, chrome.i18n.getMessage('listUnmerge')))
       )),
       styling
     ),

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -8,7 +8,7 @@ import { Export } from './components/Export.js'
 import { List } from './components/List.js'
 import { Instructions } from './components/Instructions.js'
 import { Loading } from './components/Loading.js'
-import { getId } from './utils.js'
+import { getId, toPlainSubtitles } from './utils.js'
 
 /**
  * @param {chrome.tabs.Tab} tab
@@ -31,7 +31,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const { id, storageId, title } = getTabInfo(tabs[0])
 
         // Store subtitles on changes of state
-        const stateSubtitles = [...stateItem?.subtitles?.values() || []].map(v => ({ ...v }))
+        const stateSubtitles = toPlainSubtitles(stateItem?.subtitles)
         if (id && storageId && Boolean(stateSubtitles.length)) {
           chrome.tabs.sendMessage(id, { type: 'storeSubtitles', storageId, subtitles: stateSubtitles })
         }

--- a/src/popup/utils.js
+++ b/src/popup/utils.js
@@ -28,6 +28,18 @@ export const getEnabledSubtitles = (subtitles) => {
 }
 
 /**
+ * Deep clones subtitles from the state into plain objects,
+ * needed for messages since Firefox serializes them with
+ * structured clone, which cannot copy the state proxies
+ *
+ * @param {Subtitle[]} subtitles
+ * @returns {Subtitle[]}
+ */
+export const toPlainSubtitles = (subtitles) => {
+  return JSON.parse(JSON.stringify([...subtitles?.values() || []]))
+}
+
+/**
  * Extracts and returns the id of a YouTube url
  *
  * @param {string} url

--- a/src/youtube2Anki.js
+++ b/src/youtube2Anki.js
@@ -122,7 +122,7 @@ chrome.runtime.onMessage.addListener((/** @type {Message} */request, _, sendResp
   if (type === 'download') {
     /** @type {{title: string, subtitles: Subtitle[]}} */
     const { title, subtitles } = request
-    const cleanSubtitles = subtitles.map(({ disabled, ...rest }) => rest)
+    const cleanSubtitles = subtitles.map(({ disabled, mergedFrom, ...rest }) => rest)
     const csv = toCSV(cleanSubtitles)
     download(`${title}.csv`, csv)
   }


### PR DESCRIPTION
Adds the option to merge and undo cards, now it showcases how many cards are merged.

https://github.com/user-attachments/assets/f3a67ba2-f0dd-4b4a-9e7d-f6e884d6e930

Use `scripts": ["background.js"]` for manifest compatibility for both Firefox and Chrome 